### PR TITLE
change folder

### DIFF
--- a/.github/workflows/todo-app.yml
+++ b/.github/workflows/todo-app.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/jekyll-build-pages@v1
         with:
           source: ./
-          destination: ./_site
+          destination: ./docs
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
 


### PR DESCRIPTION
🔧 (todo-app.yml): change destination folder from _site to docs to align with GitHub Pages default publishing settings